### PR TITLE
fix yaml % notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Add api/secret keys in `config.yml` and it's up!
 ```yaml
 # app/config.yml
 knp_mailjet:
-    api_key:    %mailjet_api_key%
-    secret_key: %mailjet_secret_key%
+    api_key:    "%mailjet_api_key%"
+    secret_key: "%mailjet_secret_key%"
 ```
 
 Now you can access RESTful API via DIC by calling `knp_mailjet.api` service:

--- a/Resources/config/api.yml
+++ b/Resources/config/api.yml
@@ -3,5 +3,5 @@ parameters:
 
 services:
     knp_mailjet.api:
-        class: %knp_mailjet.api.class%
-        arguments: [%knp_mailjet.api_key%, %knp_mailjet.secret_key%]
+        class: "%knp_mailjet.api.class%"
+        arguments: ["%knp_mailjet.api_key%", "%knp_mailjet.secret_key%"]

--- a/Resources/config/event.yml
+++ b/Resources/config/event.yml
@@ -4,10 +4,10 @@ parameters:
 
 services:
     knp_mailjet.event.factory:
-        class: %knp_mailjet.event.factory.class%
+        class: "%knp_mailjet.event.factory.class%"
 
     knp_mailjet.event.controller:
-        class: %knp_mailjet.event.controller.class%
+        class: "%knp_mailjet.event.controller.class%"
         arguments:
             - "@knp_mailjet.event.factory"
             - "@event_dispatcher"


### PR DESCRIPTION
Not quoting a scalar starting with the "%" indicator character is
deprecated since Symfony 3.1 and will throw a ParseException in 4.0